### PR TITLE
Update Vector Upsert Documentation

### DIFF
--- a/content/SDKs/python/api-reference.mdx
+++ b/content/SDKs/python/api-reference.mdx
@@ -175,7 +175,7 @@ Returns a `Data` object that streams the attachment content.
 
 ```python
 async def handler(request: AgentRequest, response: AgentResponse, context: AgentContext):
-    email = request.data.email()
+    email = await request.data.email()
 
     # Process attachments
     for attachment in email.attachments:


### PR DESCRIPTION
Change docs to reflect change in API: upsert takes an array of documents, not each document as a separate argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Python SDK API reference: upsert now takes a single list of documents; text and embeddings examples updated accordingly.
  * Vector search docs: use explicit parameters (query, limit, similarity, metadata) with named-argument examples.
  * Examples updated to show constructing document lists for indexing and passing keys for vectors; deletion wording now references “key” instead of “ID.”
  * Email examples updated to fetch emails asynchronously; minor wording/formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->