### PR TITLE
Update Guides and API reference pages

### DIFF
--- a/content/Guides/agent-communication.mdx
+++ b/content/Guides/agent-communication.mdx
@@ -7,15 +7,13 @@ import Image from "next/image";
 
 <Image src="/images/agent-to-agent.png" alt="Agent-to-AgentCommunication" width={640} height={640} />
 
-### How do agents communicate with each other?
+## Overview
 
-In most advanced agentic scenarios, agents need to communicate with other agents to achieve their goals.
-
-In fact, our recommendation is that you build agents with highly specialized roles and skills and use agent-to-agent communication to achieve the overall goal.
+In most advanced agentic scenarios, agents need to communicate with other agents to achieve their goals. In fact, our recommendation is that you build agents with highly specialized roles and skills and use agent-to-agent communication to achieve the overall goal.
 
 There are a number of ways to achieve agent-to-agent communication natively in Agentuity.
 
-#### Communication Types
+## Communication Types
 
 Agents can communicate with each other in a number of ways in the Agentuity platform.  The following are the different types of communication that are supported:
 
@@ -25,19 +23,19 @@ Agents can communicate with each other in a number of ways in the Agentuity plat
 | **Inter Project** | Agents can communicate with each other across projects within the same organization across the internal network |
 | **Inter Organization** | Agents can communicate with each other across organizations across the internal network |
 
-##### Intra Project
+### Intra Project
 
 Intra project communication is the simplest form of agent-to-agent communication.  Agents within the same project can communicate with each other locally without leaving the local network.
 
-##### Inter Project
+### Inter Project
 
 Inter project communication is a more advanced form of agent-to-agent communication.  Agents can communicate with each other across projects within the same organization but will communicate over the internal network.
 
-##### Inter Organization
+### Inter Organization
 
 Inter organization communication is the most advanced form of agent-to-agent communication.  Agents can communicate with each other across organizations. Currently, Agentuity only supports inter organization agent communication if the target agent is public and the source agent has been given the agent ID by the other organization. For inter organization communication, the source agent will communicate over the internal network.
 
-#### Communication Methods
+## Communication Methods
 
 Agents have two primary methods of communication with other agents:
 
@@ -46,7 +44,7 @@ Agents have two primary methods of communication with other agents:
 | Handoff | Agents can handoff a request to another agent to complete |
 | Invocation | Agents can invoke another agent to complete a task and wait for the result |
 
-##### Handoff
+### Handoff
 
 When an agent needs to handoff a request to another agent, it can do so by using the SDK `handoff` method.  The `handoff` method will send the request to another agent and the other agent will be responsible for completing the request.
 
@@ -91,7 +89,7 @@ async def run(request: AgentRequest, response: AgentResponse, context: AgentCont
     return response.handoff({"name":"My Other Agent"}, "would you please do this?")
 `} />
 
-##### Invocation
+### Invocation
 
 When an agent needs to invoke another agent to complete a task and wants to wait for the result, it can do so by using the SDK `getAgent` method on `AgentContext`.  The `getAgent` will perform resolution to determine the target agent location and return a handle to the target agent that can be used to `run` the target agent.
 
@@ -118,16 +116,16 @@ export default async function Agent(
    ctx: AgentContext
 ) {
     const agent = await ctx.getAgent({name: 'My Other Agent'});
-    const agentResponse = await agent.run({ 
-        data: "would you please do this?",
-        contentType: "text/plain"
-    });
+    // Basic usage - perfect for simple string data
+    const agentResponse = await agent.run({ data: "would you please do this?" });
+    // Explicit control when needed:
+    // const agentResponse = await agent.run({ data: "would you please do this?", contentType: "text/plain" });
     const text = await agentResponse.data.text();
     return resp.text(text);
 }`} py={`from agentuity import AgentRequest, AgentResponse, AgentContext
 
 async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
-    agent = await context.getAgent({"name":"My Other Agent"})
+    agent = await context.get_agent({"name":"My Other Agent"})
     # Send plain text (content type inferred as text/plain)
     agent_response = await agent.run("would you please do this?")
     # Or send JSON (content type inferred as application/json)
@@ -140,7 +138,7 @@ In this trivial example above, the functionality is similar to the handoff examp
 
 In a real life scenario, you'll likely want to pass the appropriate data types to the target agent and wait for the result and then use the result in your own agent to perform additional tasks.
 
-###### Parallel Execution
+#### Parallel Execution
 
 Sometimes you want to send a request to multiple agents at the same time. This is an example of parallel execution.
 
@@ -153,18 +151,24 @@ export default async function Agent(
 ) {
   const agent1 = await ctx.getAgent({name: 'My First Agent'});
   const agent2 = await ctx.getAgent({name: 'My Second Agent'});
+  // Basic usage - perfect for simple object data
   await Promise.all([
-    agent1.run({ data: { task: 'My First Task' }, contentType: 'application/json' }),
-    agent2.run({ data: { task: 'My Second Task' }, contentType: 'application/json' }),
+    agent1.run({ data: { task: 'My First Task' } }),
+    agent2.run({ data: { task: 'My Second Task' } }),
   ]);
+  // Explicit control when needed:
+  // await Promise.all([
+  //   agent1.run({ data: { task: 'My First Task' }, contentType: 'application/json' }),
+  //   agent2.run({ data: { task: 'My Second Task' }, contentType: 'application/json' }),
+  // ]);
   return resp.text('OK');
 }`}  py={`from agentuity import AgentRequest, AgentResponse, AgentContext
 import asyncio
 
 async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
 
-    agent1 = await context.getAgent({"name":"My First Agent"})
-    agent2 = await context.getAgent({"name":"My Second Agent"})
+    agent1 = await context.get_agent({"name":"My First Agent"})
+    agent2 = await context.get_agent({"name":"My Second Agent"})
 
     await asyncio.gather(
       agent1.run({"task": "My First Task"}),  # content type inferred as JSON
@@ -190,7 +194,7 @@ sequenceDiagram
   Agent 1->>Agent 3: Run
 "/>
 
-#### Agent Resolution
+## Agent Resolution
 
 How do we resolve the target agent?  There are three main ways to do this:
 
@@ -200,11 +204,11 @@ How do we resolve the target agent?  There are three main ways to do this:
 | Agent Name | The agent name is a human readable name for an agent.  It is a string that was used for the agent's name. |
 | Project ID | The agent project ID is specified to disambiguate agents with the same name in different projects. |
 
-##### Intra Project Resolution
+### Intra Project Resolution
 
 When calling an agent within the same project, the agent name is usually the easiest way to resolve the target agent.  The agent name is a human readable name for an agent.  It is a string that was used for the agent's name.
 
-##### Inter Project Resolution
+### Inter Project Resolution
 
 When calling an agent across projects within the same organization, the agent ID is typically the most reliable way to resolve the target agent.  The agent ID is a unique identifier for an agent.
 
@@ -233,10 +237,10 @@ async def run(request: AgentRequest, response: AgentResponse, context: AgentCont
     })
 `} />
 
-##### Inter Organization Resolution
+### Inter Organization Resolution
 
 Currently, Agentuity only supports inter organization agent communication if the target agent is public and the source agent has been given the agent ID by the other organization. When using inter organization communication, only the agent ID is required to resolve the target agent.
 
-#### Communication Authorization
+## Communication Authorization
 
 When communicating with other agents outside the local project, Agentuity will automatically generate a one-time use authorization token with a short expiration.  This token is used to authenticate the source agent to the target agent automatically without the need for the source agent to pass the token to the target agent.

--- a/content/Guides/agent-communication.mdx
+++ b/content/Guides/agent-communication.mdx
@@ -39,7 +39,7 @@ Inter organization communication is the most advanced form of agent-to-agent com
 
 #### Communication Methods
 
-Agents has two primary methods of communication with other agents:
+Agents have two primary methods of communication with other agents:
 
 | Type      | Description |
 |-----------|-------------|
@@ -81,7 +81,10 @@ export default async function Agent(
    resp: AgentResponse,
    ctx: AgentContext
 ) {
-    return resp.handoff({name: 'My Other Agent'}, "would you please do this?");
+    return resp.handoff(
+        {name: 'My Other Agent'}, 
+        { data: "would you please do this?", contentType: "text/plain" }
+    );
 }`} py={`from agentuity import AgentRequest, AgentResponse, AgentContext
 
 async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
@@ -90,11 +93,11 @@ async def run(request: AgentRequest, response: AgentResponse, context: AgentCont
 
 ##### Invocation
 
-When an agent needs to invoke another agent to complete a task and wants to wait for the result, it can do so by using the SDK `getAgents` method on `AgentContext`.  The `getAgents` will perform resolution to determine the target agent location and return a handle to the target agent that can be used to `run` the target agent.
+When an agent needs to invoke another agent to complete a task and wants to wait for the result, it can do so by using the SDK `getAgent` method on `AgentContext`.  The `getAgent` will perform resolution to determine the target agent location and return a handle to the target agent that can be used to `run` the target agent.
 
-If the target agent is local (intra project), the `getAgents` method will return a handle to an internal agent which can be used to `run` the target agent.
+If the target agent is local (intra project), the `getAgent` method will return a handle to an internal agent which can be used to `run` the target agent.
 
-If the target agent is remote (inter project or inter organization), the `getAgents` method will return a handle to an external agent which can be used to `run` the target agent.  In addition, the SDK internally will use the authorization token to authenticate the source agent to the target agent.
+If the target agent is remote (inter project or inter organization), the `getAgent` method will return a handle to an external agent which can be used to `run` the target agent.  In addition, the SDK internally will use the authorization token to authenticate the source agent to the target agent.
 
 <Mermaid chart="
 sequenceDiagram
@@ -115,14 +118,20 @@ export default async function Agent(
    ctx: AgentContext
 ) {
     const agent = await ctx.getAgent({name: 'My Other Agent'});
-    const agentResponse = await agent.run({name: 'My Other Agent'}, "would you please do this?");
+    const agentResponse = await agent.run({ 
+        data: "would you please do this?",
+        contentType: "text/plain"
+    });
     const text = await agentResponse.data.text();
     return resp.text(text);
 }`} py={`from agentuity import AgentRequest, AgentResponse, AgentContext
 
 async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
     agent = await context.getAgent({"name":"My Other Agent"})
-    agent_response = await agent.run({"name":"My Other Agent"}, "would you please do this?")
+    # Send plain text (content type inferred as text/plain)
+    agent_response = await agent.run("would you please do this?")
+    # Or send JSON (content type inferred as application/json)
+    # agent_response = await agent.run({"message": "would you please do this?"})
     text = await agent_response.data.text()
     return response.text(text)
 `} />
@@ -145,8 +154,8 @@ export default async function Agent(
   const agent1 = await ctx.getAgent({name: 'My First Agent'});
   const agent2 = await ctx.getAgent({name: 'My Second Agent'});
   await Promise.all([
-    agent1.run({task: 'My First Task'}),
-    agent2.run({task: 'My Second Task'}),
+    agent1.run({ data: { task: 'My First Task' }, contentType: 'application/json' }),
+    agent2.run({ data: { task: 'My Second Task' }, contentType: 'application/json' }),
   ]);
   return resp.text('OK');
 }`}  py={`from agentuity import AgentRequest, AgentResponse, AgentContext
@@ -158,8 +167,8 @@ async def run(request: AgentRequest, response: AgentResponse, context: AgentCont
     agent2 = await context.getAgent({"name":"My Second Agent"})
 
     await asyncio.gather(
-      agent1.run({"task":"My First Task"}),
-      agent2.run({"task":"My Second Task"}),
+      agent1.run({"task": "My First Task"}),  # content type inferred as JSON
+      agent2.run({"task": "My Second Task"}), # content type inferred as JSON
     )
 
     return response.text('OK')
@@ -175,15 +184,15 @@ sequenceDiagram
   actor Agentuity
   actor Agent 2
   actor Agent 3
-  Agent 1-->>Agentuity: Get Agent 1
   Agent 1-->>Agentuity: Get Agent 2
+  Agent 1-->>Agentuity: Get Agent 3
   Agent 1->>Agent 2: Run
   Agent 1->>Agent 3: Run
 "/>
 
 #### Agent Resolution
 
-How do we resolve the target agent?  There are two main ways to do this:
+How do we resolve the target agent?  There are three main ways to do this:
 
 | Type      | Description |
 |-----------|-------------|

--- a/content/Guides/agent-data-handling.mdx
+++ b/content/Guides/agent-data-handling.mdx
@@ -3,7 +3,9 @@ title: Agent Data Handling
 description: How to handle data formats in your agents
 ---
 
-We provide a few different ways to handle data formats in your agents to make it easier to work with different data types.  Of course, your agent can always perform its own data handling by use the raw data and the content type property.  However, most common data types are supported out of the box.
+## Overview
+
+We provide a few different ways to handle data formats in your agents to make it easier to work with different data types. Of course, your agent can always perform its own data handling by using the raw data and the content type property. However, most common data types are supported out of the box.
 
 ## How it works
 

--- a/content/Guides/agent-streaming.mdx
+++ b/content/Guides/agent-streaming.mdx
@@ -26,7 +26,7 @@ description: How to use streaming in your agents
 └────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-#### Real-World Use Cases
+### Real-World Use Cases
 
 - **Live chat / customer support.** Stream the assistant's words as they are generated for a more natural feel.
 - **Speech-to-text.** Pipe microphone audio into a transcription agent and forward captions to the UI in real time.

--- a/content/Guides/agent-tracing.mdx
+++ b/content/Guides/agent-tracing.mdx
@@ -3,6 +3,8 @@ title: Agent Tracing
 description: Understanding how to use tracing in your agents
 ---
 
+## Overview
+
 Agent tracing provides deep visibility into your agent's execution flow, performance, and behavior using OpenTelemetry. This enables debugging, performance monitoring, and understanding complex agent workflows.
 
 **Key benefits:**

--- a/content/Guides/ai-gateway.mdx
+++ b/content/Guides/ai-gateway.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using AI Gateway
-description: Using AI Gateway in your Agents
+description: Using the AI Gateway in your Agents
 ---
 
 ## What is the AI Gateway?

--- a/content/Guides/key-value.mdx
+++ b/content/Guides/key-value.mdx
@@ -38,14 +38,14 @@ Both JavaScript and Python SDKs automatically create key-value storage when you 
 <CodeExample js={`// JavaScript/TypeScript
 import { AgentHandler } from '@agentuity/sdk';
 
-const handler: AgentHandler = async (request, response, context) => {
-  // Storage is created automatically on first use
-  await context.kv.set('user-sessions', 'user-123', {
+const handler: AgentHandler = async (req, resp, ctx) => {
+  // Buckets are auto-created if they don't exist
+  await ctx.kv.set('user-sessions', 'user-123', {
     lastSeen: new Date().toISOString(),
     preferences: { theme: 'dark' }
   });
   
-  return response.json({ message: 'Session stored' });
+  return resp.json({ message: 'Session stored' });
 };
 
 export default handler;`} py={`# Python
@@ -66,46 +66,59 @@ async def run(request: AgentRequest, response: AgentResponse, context: AgentCont
 
 The key-value API provides three core operations: `get`, `set`, and `delete`. All operations are asynchronous and support various data types.
 
+The first parameter in all operations is the storage bucket name (also called "name" or "namespace"). Buckets are automatically created when you first use them.
+
 ### Storing Data
 
-Store strings, objects, or binary data with optional TTL (time-to-live):
+Store strings, objects, or binary data. Keys persist indefinitely by default, or you can set a TTL (time-to-live) for automatic expiration:
 
-<CodeExample js={`// Store a string
-await context.kv.set('cache', 'api-response', responseData);
+<CodeExample js={`// Simple store
+await ctx.kv.set('cache', 'api-response', responseData);
 
-// Store an object (automatically serialized)
-await context.kv.set('user-prefs', userId, {
+// Store an object
+await ctx.kv.set('user-prefs', userId, {
   language: 'en',
   timezone: 'UTC'
 });
 
 // Store with TTL (expires after 1 hour)
-await context.kv.set('sessions', sessionId, userData, 3600);
+await ctx.kv.set('sessions', sessionId, userData, { 
+  ttl: 3600,  // seconds
+  contentType: 'application/json'
+});
 
-// Store binary data
-const buffer = Buffer.from('binary data');
-await context.kv.set('files', 'document.pdf', buffer);`} py={`# Store a string
+// Store feature flags (no TTL - persistent config)
+await ctx.kv.set('feature-flags', 'beta-features', {
+  darkMode: true,
+  aiAssistant: false,
+  newDashboard: true
+});`} py={`# Simple store
 await context.kv.set("cache", "api-response", response_data)
 
-# Store an object (automatically serialized)
+# Store an object
 await context.kv.set("user-prefs", user_id, {
     "language": "en",
     "timezone": "UTC"
 })
 
 # Store with TTL (expires after 1 hour)
-await context.kv.set("sessions", session_id, user_data, {"ttl": 3600})
+await context.kv.set("sessions", session_id, user_data, {
+    "ttl": 3600  # seconds
+})
 
-# Store binary data
-binary_data = b"binary data"
-await context.kv.set("files", "document.pdf", binary_data)`} />
+# Store feature flags (no TTL - persistent config)
+await context.kv.set("feature-flags", "beta-features", {
+    "darkMode": True,
+    "aiAssistant": False,
+    "newDashboard": True
+})`} />
 
 ### Retrieving Data
 
 Retrieve stored values with automatic deserialization:
 
 <CodeExample js={`// Get a value
-const result = await context.kv.get('user-prefs', userId);
+const result = await ctx.kv.get('user-prefs', userId);
 
 if (result.exists) {
   // Access data using the Data interface
@@ -116,8 +129,8 @@ if (result.exists) {
 }
 
 // Handle missing keys gracefully
-const result = await context.kv.get('config', 'app-settings');
-const config = result.exists ? await result.data.json() : defaultConfig;`} py={`# Get a value
+const configResult = await ctx.kv.get('config', 'app-settings');
+const config = configResult.exists ? await configResult.data.json() : defaultConfig;`} py={`# Get a value
 result = await context.kv.get("user-prefs", user_id)
 
 if result.exists:
@@ -136,7 +149,7 @@ config = await result.data.json() if result.exists else default_config`} />
 Remove keys when they're no longer needed:
 
 <CodeExample js={`// Delete a single key
-await context.kv.delete('sessions', sessionId);
+await ctx.kv.delete('sessions', sessionId);
 console.log('Session deleted successfully');`} py={`# Delete a single key
 await context.kv.delete("sessions", session_id)
 print("Session deleted successfully")`} />
@@ -155,13 +168,13 @@ Use hierarchical, descriptive keys to organize your data:
 Always handle potential storage errors gracefully:
 
 <CodeExample js={`try {
-  const result = await context.kv.get('config', 'settings');
+  const result = await ctx.kv.get('config', 'settings');
   if (!result.exists) {
     // Initialize with defaults
-    await context.kv.set('config', 'settings', defaultSettings);
+    await ctx.kv.set('config', 'settings', defaultSettings);
   }
 } catch (error) {
-  context.logger.error('Storage error:', error);
+  ctx.logger.error('Storage error:', error);
   // Fall back to in-memory defaults
 }`} py={`try:
     result = await context.kv.get("config", "settings")
@@ -174,10 +187,13 @@ except Exception as e:
 
 ### TTL Strategy
 
+Keys persist indefinitely by default unless you specify a TTL (time-to-live) value. When you do specify a TTL, the minimum allowed value is 60 seconds.
+
 Use TTL for temporary data to prevent storage bloat:
 - **Session data**: 24-48 hours
 - **API cache**: 5-60 minutes
 - **Rate limiting counters**: Until period reset
+- **Permanent config**: No TTL (keys persist forever)
 
 ### Data Size Considerations
 

--- a/content/Guides/vector-db.mdx
+++ b/content/Guides/vector-db.mdx
@@ -3,7 +3,15 @@ title: Using Vector DB
 description: Using the Vector DB for search and retrieval
 ---
 
+## When to Use Vector Storage
+
 Vector storage enables semantic search for your agents, allowing them to find information by meaning rather than keywords. Ideal for knowledge bases, RAG systems, and persistent agent memory.
+
+Choose the right storage for your use case:
+
+- **Vector Storage**: Semantic search, embeddings, similarity matching
+- **[Key-Value Storage](/Cloud/key-value-memory)**: Fast lookups, simple data, temporary state
+- **[Object Storage](/Cloud/object-storage)**: Large files, media, backups
 
 ## Understanding Vector Storage
 
@@ -58,9 +66,7 @@ The `upsert` operation inserts new documents or updates existing ones. You can p
 **Idempotent Behavior:**
 The upsert operation is idempotent - upserting with an existing key updates the existing vector rather than creating a duplicate. The same internal vector ID is reused, ensuring your vector storage remains clean and efficient.
 
-<CodeExample>
-```javascript
-// JavaScript/TypeScript
+<CodeExample js={`// JavaScript/TypeScript
 // Upsert documents with text (automatic embedding)
 const ids = await context.vector.upsert(
   'knowledge-base',
@@ -84,11 +90,7 @@ const embeddingIds = await context.vector.upsert(
     embeddings: [0.1, 0.2, 0.3, 0.4], 
     metadata: { id: 'doc-1', type: 'custom' } 
   }
-);
-```
-
-```python
-# Python
+);`} py={`# Python
 # Upsert documents with text
 documents = [
     {
@@ -114,17 +116,13 @@ embedding_docs = [
     }
 ]
 
-ids = await context.vector.upsert("custom-embeddings", embedding_docs)
-```
-</CodeExample>
+ids = await context.vector.upsert("custom-embeddings", embedding_docs)`} />
 
 ### Searching Vector Storage
 
 Search operations find semantically similar documents based on a text query. You can control the number of results, similarity threshold, and filter by metadata.
 
-<CodeExample>
-```javascript
-// JavaScript/TypeScript
+<CodeExample js={`// JavaScript/TypeScript
 // Basic semantic search
 const results = await context.vector.search('knowledge-base', {
   query: 'What is an agent platform?',
@@ -135,13 +133,9 @@ const results = await context.vector.search('knowledge-base', {
 
 // Process results
 results.forEach(result => {
-  console.log(`Found: ${result.metadata.source}`);
-  console.log(`Similarity: ${result.similarity}`);
-});
-```
-
-```python
-# Python
+  console.log(\`Found: \${result.metadata.source}\`);
+  console.log(\`Similarity: \${result.similarity}\`);
+});`} py={`# Python
 # Semantic search with parameters
 results = await context.vector.search(
     "knowledge-base",
@@ -154,9 +148,7 @@ results = await context.vector.search(
 # Process results
 for result in results:
     print(f"Found: {result.metadata['source']}")
-    print(f"Similarity: {result.similarity}")
-```
-</CodeExample>
+    print(f"Similarity: {result.similarity}")`} />
 
 **Search Parameters:**
 - `query` (required): Text query to search for
@@ -168,33 +160,105 @@ for result in results:
 - **Both SDKs**: Return results with `similarity` field (1.0 = perfect match, 0.0 = no match)
 - **Note**: The JavaScript SDK also returns a `distance` field for backward compatibility; prefer `similarity`
 
+### Retrieving Vectors by Key
+
+The `get` method retrieves a specific vector directly using its key, without performing a similarity search.
+
+<CodeExample js={`// JavaScript/TypeScript
+// Direct lookup by key
+const vector = await context.vector.get('knowledge-base', 'doc-1');
+
+if (vector) {
+  console.log(\`Found: \${vector.id}\`);
+  console.log(\`Key: \${vector.key}\`);
+  console.log('Metadata:', vector.metadata);
+} else {
+  console.log('Vector not found');
+}
+
+// Common use cases:
+
+// 1. Check if a vector exists before updating
+const existing = await context.vector.get('products', 'product-123');
+if (existing) {
+  // Update with merged metadata
+  await context.vector.upsert('products', {
+    key: 'product-123',
+    document: 'Updated product description',
+    metadata: { ...existing.metadata, lastUpdated: Date.now() }
+  });
+}
+
+// 2. Retrieve full metadata after search
+const searchResults = await context.vector.search('products', {
+  query: 'office chair',
+  limit: 5
+});
+
+// Get complete details for the top result
+if (searchResults[0]) {
+  const fullDetails = await context.vector.get('products', searchResults[0].key);
+  console.log('Full metadata:', fullDetails?.metadata);
+}`} py={`# Python
+# Direct lookup by key
+vector = await context.vector.get("knowledge-base", "doc-1")
+
+if vector:
+    print(f"Found: {vector.id}")
+    print(f"Key: {vector.key}")
+    print(f"Metadata: {vector.metadata}")
+else:
+    print("Vector not found")
+
+# Common use cases:
+
+# 1. Check if a vector exists before updating
+existing = await context.vector.get("products", "product-123")
+if existing:
+    # Update with merged metadata
+    await context.vector.upsert("products", [{
+        "key": "product-123",
+        "document": "Updated product description",
+        "metadata": {**existing.metadata, "lastUpdated": int(time.time())}
+    }])
+
+# 2. Retrieve full metadata after search
+search_results = await context.vector.search(
+    "products",
+    query="office chair",
+    limit=5
+)
+
+# Get complete details for the top result
+if search_results:
+    full_details = await context.vector.get("products", search_results[0].key)
+    if full_details:
+        print(f"Full metadata: {full_details.metadata}")`} />
+
+**When to use `get` vs `search`:**
+- Use `get` when you know the exact key (like a database primary key lookup)
+- Use `search` when finding vectors by semantic similarity
+- `get` is faster for single lookups since it doesn't compute similarities
+- `get` returns `null` if not found, never throws an error
+
 ### Deleting Vectors
 
 Remove specific vectors from storage using their keys.
 
-<CodeExample>
-```javascript
-// JavaScript/TypeScript
+<CodeExample js={`// JavaScript/TypeScript
 // Delete single vector
 const deletedCount = await context.vector.delete('knowledge-base', 'doc-1');
-
 
 // Delete multiple vectors
 const bulkDeleteCount = await context.vector.delete(
   'knowledge-base', 
   'doc-1', 'doc-2', 'doc-3'
-);
-```
-
-```python
-# Python
+);`} py={`# Python
 # Delete single vector
 count = await context.vector.delete("knowledge-base", "doc_1")
 
 # Note: Python SDK currently supports single deletion
-# For bulk operations, call delete multiple times
-```
-</CodeExample>
+# For bulk operations, call delete multiple times`} />
 
 ## Practical Examples
 

--- a/content/SDKs/javascript/api-reference.mdx
+++ b/content/SDKs/javascript/api-reference.mdx
@@ -270,6 +270,36 @@ for (const result of results) {
 }
 ```
 
+#### get
+
+`get(name: string, key: string): Promise<VectorSearchResult | null>`
+
+Retrieves a specific vector from the vector storage using its key.
+
+**Parameters**
+
+- `name`: The name of the vector storage
+- `key`: The unique key of the vector to retrieve
+
+**Return Value**
+
+Returns a Promise that resolves to a `VectorSearchResult` object if found, or `null` if the key doesn't exist.
+
+**Example**
+
+```typescript
+// Retrieve a specific vector by key
+const vector = await context.vector.get('product-descriptions', 'chair-001');
+
+if (vector) {
+  console.log(`Found vector: ${vector.id}`);
+  console.log(`Key: ${vector.key}`);
+  console.log(`Metadata:`, vector.metadata);
+} else {
+  console.log('Vector not found');
+}
+```
+
 #### delete
 
 `delete(name: string, ...keys: string[]): Promise<number>`

--- a/content/SDKs/python/api-reference.mdx
+++ b/content/SDKs/python/api-reference.mdx
@@ -493,6 +493,35 @@ except Exception as e:
     # Handle the error appropriately
 ```
 
+#### get
+
+`async get(name: str, key: str) -> VectorSearchResult | None`
+
+Retrieves a specific vector from the vector storage using its key.
+
+**Parameters**
+
+- `name`: The name of the vector storage
+- `key`: The unique key of the vector to retrieve
+
+**Return Value**
+
+Returns a `VectorSearchResult` object if found, or `None` if the key doesn't exist.
+
+**Example**
+
+```python
+# Retrieve a specific vector by key
+vector = await context.vector.get("product-descriptions", "chair-001")
+
+if vector:
+    print(f"Found vector: {vector.id}")
+    print(f"Key: {vector.key}")
+    print(f"Metadata: {vector.metadata}")
+else:
+    print("Vector not found")
+```
+
 #### delete
 
 `async delete(name: str, key: str) -> int`

--- a/content/SDKs/python/api-reference.mdx
+++ b/content/SDKs/python/api-reference.mdx
@@ -752,12 +752,13 @@ agent = await context.get_agent({"id": "agent-123"})
 # Get an agent by name
 agent2 = await context.get_agent({
     "name": "data-processing-agent",
-    "project_id": "project-456"
+    "projectId": "project-456" # Note: projectId is camelCase
 })
 
 # Invoke the agent with error handling
 try:
-    result = await agent.run({"data": "process this"}, "application/json")
+    # Just pass the data (content type is inferred)
+    result = await agent.run({"data": "process this"})
     # Process the result
     print(f"Agent response: {result}")
 except Exception as e:


### PR DESCRIPTION
- Fix incorrect agent communication examples (e.g., `get_agent`)
- Add `vector.get()` usage to API reference, examples in Guides
- Fix code formatting for Vector DB guide
- Clean up Guides headings