### PR TITLE
Add callout for credits/billing in AI Gateway Guide

### DIFF
--- a/content/Guides/ai-gateway.mdx
+++ b/content/Guides/ai-gateway.mdx
@@ -22,7 +22,7 @@ The AI Gateway supports the following providers out of the box:
 - **Perplexity**
 
 <Callout type="info">
-Ready to try out the AI Gateway? [Manage your billing and purchase credits](https://app.agentuity.com/billing) in the Cloud Console.
+[Purchase credits and manage billing](https://app.agentuity.com/billing) in the Cloud Console.
 </Callout>
 
 ## How It Works

--- a/content/Guides/ai-gateway.mdx
+++ b/content/Guides/ai-gateway.mdx
@@ -21,6 +21,10 @@ The AI Gateway supports the following providers out of the box:
 - **Mistral**
 - **Perplexity**
 
+<Callout type="info">
+Ready to try out the AI Gateway? [Manage your billing and purchase credits](https://app.agentuity.com/billing) in the Cloud Console to get started.
+</Callout>
+
 ## How It Works
 
 ### Automatic Detection

--- a/content/Guides/ai-gateway.mdx
+++ b/content/Guides/ai-gateway.mdx
@@ -22,7 +22,7 @@ The AI Gateway supports the following providers out of the box:
 - **Perplexity**
 
 <Callout type="info">
-Ready to try out the AI Gateway? [Manage your billing and purchase credits](https://app.agentuity.com/billing) in the Cloud Console to get started.
+Ready to try out the AI Gateway? [Manage your billing and purchase credits](https://app.agentuity.com/billing) in the Cloud Console.
 </Callout>
 
 ## How It Works


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an informational Callout under “Supported Providers” in the AI Gateway guide directing users to the Cloud Console to manage billing and purchase credits.
  - Improves clarity and discoverability of account and billing actions within the guide; strictly presentational content with no functional, API, or public-interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->