### PR TITLE
Fix streaming docs

### DIFF
--- a/content/Guides/agent-streaming.mdx
+++ b/content/Guides/agent-streaming.mdx
@@ -116,11 +116,7 @@ The SDK automatically detects object streams and converts them to JSON newline f
 
 ### Stream Transformers
 
-You can provide transformer functions to filter and transform stream data. The `resp.stream()` signature is:
-
-```ts
-stream(source, contentType?, metadata?, transformer?)
-```
+You can provide an optional `transformer` parameter to `resp.stream()` to filter and transform stream data before it's sent to the client:
 
 <CodeExample js={`import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
 
@@ -259,6 +255,8 @@ await writer.write(new Uint8Array([72, 101, 108, 108]));  // Binary - passed thr
 
 The SDK handles JSON serialization and UTF-8 encoding as needed.
 
+**Note:** While the SDK auto-serializes objects to JSON, it doesn't include line terminators. When streaming multiple JSON objects (such as NDJSON - newline-delimited JSON), you'll need to manually add delimiters between objects. See the example below for a common pattern.
+
 ```ts
 export default async function Agent(
   req: AgentRequest,
@@ -287,8 +285,8 @@ export default async function Agent(
           timestamp: new Date().toISOString()
         };
 
-        // SDK handles encoding - pass strings, objects, or binary data directly
-        await writer.write(`${JSON.stringify(progressData)}\n`);
+        // Streaming multiple JSON objects line-by-line (NDJSON pattern)
+        await writer.write(JSON.stringify(progressData) + '\n');
 
         // Simulate work
         await new Promise(resolve => setTimeout(resolve, 1000));

--- a/content/SDKs/javascript/api-reference.mdx
+++ b/content/SDKs/javascript/api-reference.mdx
@@ -664,7 +664,7 @@ The Stream Storage API provides first-class support for creating and managing se
 
 #### create
 
-`create(name: string, props?: StreamCreateProps): Stream`
+`create(name: string, props?: StreamCreateProps): Promise<Stream>`
 
 Creates a new, named, writable stream that returns immediately for non-blocking operation.
 
@@ -677,7 +677,7 @@ Creates a new, named, writable stream that returns immediately for non-blocking 
 
 **Return Value**
 
-Returns a `Stream` object immediately with the following properties:
+Returns a `Promise<Stream>` that resolves immediately with the following properties:
 - `id`: The unique identifier of the stream
 - `url`: The URL to consume the stream
 - Extends `WritableStream` for standard stream operations
@@ -757,14 +757,16 @@ const handler: AgentHandler = async (request, response, context) => {
 
     try {
       for (let i = 0; i < steps.length; i++) {
-        // SDK handles string encoding automatically
-        await writer.write(`${JSON.stringify({
+        const progressData = {
           step: i + 1,
           total: steps.length,
           message: steps[i],
           progress: ((i + 1) / steps.length) * 100,
           timestamp: new Date().toISOString()
-        })}\n`);
+        };
+
+        // Streaming multiple JSON objects line-by-line (NDJSON pattern)
+        await writer.write(JSON.stringify(progressData) + '\n');
 
         // Simulate processing time
         await new Promise(resolve => setTimeout(resolve, 1000));
@@ -889,11 +891,12 @@ const handler: AgentHandler = async (request, response, context) => {
 
       try {
         for (let i = 1; i <= 5; i++) {
-          await writer.write(`${JSON.stringify({
+          // Streaming multiple JSON objects line-by-line (NDJSON pattern)
+          await writer.write(JSON.stringify({
             id: i,
             message: `Data chunk ${i}`,
             timestamp: new Date().toISOString()
-          })}\n`);
+          }) + '\n');
           await new Promise(resolve => setTimeout(resolve, 500));
         }
       } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarifies streaming usage with explicit content types and optional transformer parameter.
  * Updates examples to show asynchronous stream creation (create now returns Promise) and awaiting.
  * Adds pipeTo guidance for non-blocking piping and demonstrates getWriter()/getReader() patterns.
  * Adopts NDJSON writer-based streaming, with explicit releaseLock()/close() lifecycle handling.
  * Refreshes samples, comments, and formatting to reflect new streaming APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->